### PR TITLE
Allows access to WebJEAUsername in onload script, fixes #4

### DIFF
--- a/WebJEA/default.aspx.vb
+++ b/WebJEA/default.aspx.vb
@@ -115,13 +115,16 @@
                 panelOnload.Attributes("class") = panelOnload.Attributes("class") & " collapse"
             Else 'run the script and display it
                 Dim ps As New PSEngine
+                Dim pswebonload As New PSWebHelper
                 ps.Script = cmd.OnloadScript
                 ps.LogParameters = cmd.LogParameters
+                'pass in parameters to onload script
+                ps.Parameters = pswebonload.getParameters(cmd, Page)
                 ps.Run()
                 objTelemetry.AddRuntime(ps.Runtime)
                 objTelemetry.AddIsOnload(True)
 
-                consoleOnload.InnerHtml = psweb.ConvertToHTML(ps.getOutputData)
+                consoleOnload.InnerHtml = pswebonload.ConvertToHTML(ps.getOutputData)
                 ps = Nothing
 
             End If


### PR DESCRIPTION
This change enables passing parameters into the onload script. The key thing we can use with this is accessing the `$WebJEAUsername` variable in the onload to present options based on the username.