### PR TITLE
docs: move the wiki into docs/ and generate the wiki from it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,10 @@ on:
       - 'Test/Integration/**'
       - 'Test/Dev/**'
       - 'Test/Scripts/**'
+      # Wiki publishing only - listed by name so that changes to build.ps1,
+      # build.psake.ps1, release.yml and test.yml still trigger a build.
+      - '.github/workflows/wiki-sync.yml'
+      - '.github/workflows/sync-wiki.ps1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-wiki.ps1
+++ b/.github/workflows/sync-wiki.ps1
@@ -1,0 +1,299 @@
+<#
+.SYNOPSIS
+    Renders docs\ into a GitHub wiki working tree.
+
+.DESCRIPTION
+    docs\ in this repo is the single source of truth for user documentation.
+    The wiki at https://github.com/markdomansky/WebJEA/wiki is a generated
+    mirror - nobody edits it directly. This script converts docs\ into the
+    layout a wiki clone expects and is invoked by wiki-sync.yml on every push
+    to master that touches docs\.
+
+    Conversions applied:
+
+    1. File name -> wiki page name. Wiki page titles come from the file name
+       with hyphens shown as spaces, so docs\README.md becomes Home.md and the
+       lowercase file names get readable titles via $PageNameOverrides.
+    2. Intra-docs links. [x](Usage.md) and [x](docker.md#configuration) become
+       [x](Usage) and [x](Docker#configuration) - wiki links carry no .md.
+       An unresolvable *.md link is a hard error, which is how a typo or a
+       deleted page gets caught before it reaches the wiki.
+    3. Links out of docs\ (../readme.md, ../docker/examples/...) become
+       absolute github.com/<repo>/blob|tree/<ref>/... URLs, since the wiki is
+       a separate repository with no view of the code.
+    4. A "generated - edit docs\ instead" banner is injected into every page,
+       plus a _Sidebar.md built from docs\README.md and a _Footer.md.
+    5. Non-markdown files under docs\ (images and the like) are copied through
+       with their relative paths intact.
+
+    Anything left in the wiki tree that this run did not produce is deleted, so
+    the wiki is a true mirror rather than an accumulation.
+
+.PARAMETER DocsPath
+    Path to the docs folder to render. Default: docs\ beside this repo root.
+
+.PARAMETER WikiPath
+    Path to a checkout of the <repo>.wiki repository. Its tracked content is
+    replaced by the rendered output.
+
+.PARAMETER Repo
+    owner/name used to build absolute links back into the code repository.
+    Default: markdomansky/WebJEA.
+
+.PARAMETER Ref
+    Branch or tag the absolute links point at. Default: master.
+
+.PARAMETER TestOnly
+    Render into a temporary folder and report what would change, without
+    touching WikiPath.
+
+.EXAMPLE
+    .\sync-wiki.ps1 -WikiPath ..\WebJEA.wiki -TestOnly
+
+.EXAMPLE
+    .\sync-wiki.ps1 -WikiPath $env:RUNNER_TEMP\wiki
+
+.OUTPUTS
+    Hashtable:
+    - Pages:   rendered page file names
+    - Assets:  copied non-markdown files
+    - Removed: files deleted from the wiki tree
+    - WikiPath: where the output was written
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$DocsPath = (Join-Path $PSScriptRoot '..\..\docs'),
+
+    [Parameter(Mandatory)]
+    [string]$WikiPath,
+
+    [Parameter()]
+    [string]$Repo = 'markdomansky/WebJEA',
+
+    [Parameter()]
+    [string]$Ref = 'master',
+
+    [Parameter()]
+    [switch]$TestOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Wiki page name for a docs file base name. Anything not listed is title-cased
+# per hyphen-separated word, which already reads correctly for the Title-Case
+# file names (System-Requirements -> "System Requirements"). Add an entry here
+# when a new docs file needs a title the file name cannot express.
+$PageNameOverrides = @{
+    'README'               = 'Home'
+    'deployment-migration' = 'Deployment-and-Migration'
+    'dev'                  = 'Development-Auto-Login'
+    'entra'                = 'Entra-ID'
+    'powershell7'          = 'PowerShell-7'
+    'windows'              = 'Windows-Authentication'
+}
+
+function Get-PageName {
+    param([Parameter(Mandatory)][string]$BaseName)
+
+    if ($PageNameOverrides.ContainsKey($BaseName)) {
+        return $PageNameOverrides[$BaseName]
+    }
+    # Title-case each word; leave the hyphens, GitHub renders them as spaces.
+    return (($BaseName -split '-' | ForEach-Object {
+        if ($_.Length -gt 0) { $_.Substring(0, 1).ToUpperInvariant() + $_.Substring(1) } else { $_ }
+    }) -join '-')
+}
+
+$docsRoot = (Resolve-Path $DocsPath).Path
+$repoUrl = "https://github.com/$Repo"
+
+$markdown = Get-ChildItem -Path $docsRoot -Filter '*.md' -File | Sort-Object Name
+if (-not $markdown) { throw "No markdown files found under '$docsRoot'." }
+
+# Source file name (lowercased) -> wiki page name, for link rewriting.
+$pageMap = @{}
+foreach ($file in $markdown) {
+    $pageMap[$file.Name.ToLowerInvariant()] = Get-PageName -BaseName $file.BaseName
+}
+
+function Convert-Links {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Text,
+        [Parameter(Mandatory)][string]$SourceName
+    )
+
+    $broken = [System.Collections.Generic.List[string]]::new()
+
+    $result = [regex]::Replace($Text, '(?<=\]\()([^)\s]+)(?=\))', {
+        param($m)
+        $target = $m.Groups[1].Value
+
+        # Absolute URLs, mailto: and same-page anchors need no change - wiki
+        # anchors are generated from headings exactly as they are on github.com.
+        if ($target -match '^([a-z][a-z0-9+.-]*:|#|//)') { return $target }
+
+        # Anything reaching outside docs\ lives in the code repo, not the wiki.
+        if ($target.StartsWith('../')) {
+            $path = $target.Substring(3)
+            $kind = if ($path.EndsWith('/')) { 'tree' } else { 'blob' }
+            return "$repoUrl/$kind/$Ref/$($path.TrimEnd('/'))"
+        }
+
+        $file, $anchor = $target -split '#', 2
+        if ($file -notmatch '\.md$') { return $target }
+
+        $page = $pageMap[$file.ToLowerInvariant()]
+        if (-not $page) {
+            $broken.Add("$SourceName -> $target")
+            return $target
+        }
+        if ($anchor) { return "$page#$anchor" }
+        return $page
+    })
+
+    return [pscustomobject]@{ Text = $result; Broken = $broken }
+}
+
+function Add-Banner {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [Parameter(Mandatory)][string]$SourceName
+    )
+
+    $banner = "> **This page is generated.** It mirrors " +
+        "[``docs/$SourceName``]($repoUrl/blob/$Ref/docs/$SourceName) in the " +
+        "[WebJEA repository]($repoUrl). Edits made here are overwritten by the " +
+        "next sync - please open a pull request against ``docs/`` instead."
+
+    $lines = $Text -split "`r?`n"
+    # Keep the H1 first so the page still reads correctly, banner right below it.
+    if ($lines.Count -gt 0 -and $lines[0] -match '^#\s') {
+        return (@($lines[0], '', $banner) + $lines[1..($lines.Count - 1)]) -join "`n"
+    }
+    return (@($banner, '') + $lines) -join "`n"
+}
+
+function New-Sidebar {
+    param([Parameter(Mandatory)][string]$ReadmeText)
+
+    # docs\README.md is already a complete, grouped index of every page, so the
+    # sidebar is that index with the prose descriptions trimmed off.
+    $out = [System.Collections.Generic.List[string]]::new()
+    $out.Add("### [WebJEA]($($pageMap['readme.md']))")
+    $out.Add('')
+
+    # A heading is only emitted once a bullet turns up under it, so prose-only
+    # sections of README (such as "About these documents") leave no empty group.
+    $pending = $null
+    foreach ($line in ($ReadmeText -split "`r?`n")) {
+        if ($line -match '^##\s+(.+?)\s*$') {
+            $pending = $Matches[1]
+            continue
+        }
+        # Only the bullet's own line carries the link; wrapped description lines
+        # are indented and get skipped, which is what we want in a sidebar.
+        if ($line -match '^\*\s+(\[[^]]+\]\([^)]+\))') {
+            if ($pending) {
+                if ($out[$out.Count - 1] -ne '') { $out.Add('') }
+                $out.Add("**$pending**")
+                $pending = $null
+            }
+            $out.Add("* $($Matches[1])")
+        }
+    }
+
+    return ($out -join "`n").Trim() + "`n"
+}
+
+$stage = Join-Path ([System.IO.Path]::GetTempPath()) ("webjea-wiki-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $stage -Force | Out-Null
+
+try {
+    $broken = [System.Collections.Generic.List[string]]::new()
+    $pages = [System.Collections.Generic.List[string]]::new()
+    $readmeRendered = $null
+
+    foreach ($file in $markdown) {
+        $page = $pageMap[$file.Name.ToLowerInvariant()]
+        $raw = Get-Content -LiteralPath $file.FullName -Raw
+
+        $converted = Convert-Links -Text $raw -SourceName $file.Name
+        $broken.AddRange($converted.Broken)
+
+        if ($file.Name -ieq 'README.md') { $readmeRendered = $converted.Text }
+
+        $body = (Add-Banner -Text $converted.Text -SourceName $file.Name).TrimEnd() + "`n"
+        Set-Content -LiteralPath (Join-Path $stage "$page.md") -Value $body -NoNewline -Encoding utf8
+        $pages.Add("$page.md")
+    }
+
+    if ($broken.Count -gt 0) {
+        throw "Unresolved documentation links (fix the link or add the page to docs\):`n  " +
+            ($broken -join "`n  ")
+    }
+
+    if ($readmeRendered) {
+        Set-Content -LiteralPath (Join-Path $stage '_Sidebar.md') `
+            -Value (New-Sidebar -ReadmeText $readmeRendered) -NoNewline -Encoding utf8
+        $pages.Add('_Sidebar.md')
+    }
+
+    $footer = "_Generated from [``docs/``]($repoUrl/tree/$Ref/docs) on the " +
+        "``$Ref`` branch of the [WebJEA repository]($repoUrl). " +
+        "Do not edit the wiki directly - changes here are overwritten._`n"
+    Set-Content -LiteralPath (Join-Path $stage '_Footer.md') -Value $footer -NoNewline -Encoding utf8
+    $pages.Add('_Footer.md')
+
+    # Images and other attachments referenced by the docs, path preserved.
+    $assets = [System.Collections.Generic.List[string]]::new()
+    foreach ($asset in (Get-ChildItem -Path $docsRoot -File -Recurse | Where-Object { $_.Extension -ne '.md' })) {
+        $relative = [System.IO.Path]::GetRelativePath($docsRoot, $asset.FullName)
+        $destination = Join-Path $stage $relative
+        New-Item -ItemType Directory -Path (Split-Path -Parent $destination) -Force | Out-Null
+        Copy-Item -LiteralPath $asset.FullName -Destination $destination -Force
+        $assets.Add($relative)
+    }
+
+    if ($TestOnly) {
+        Write-Host "Rendered $($pages.Count) pages and $($assets.Count) assets to '$stage' (test only)."
+        return @{
+            Pages    = $pages.ToArray()
+            Assets   = $assets.ToArray()
+            Removed  = @()
+            WikiPath = $stage
+        }
+    }
+
+    $wikiRoot = (Resolve-Path $WikiPath).Path
+
+    # Replace the wiki's content wholesale: anything the docs no longer produce
+    # is a stale page and must go. .git is the wiki clone's own metadata.
+    $removed = [System.Collections.Generic.List[string]]::new()
+    $keep = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in $pages) { $keep.Add($name) | Out-Null }
+    foreach ($name in $assets) { $keep.Add($name) | Out-Null }
+
+    foreach ($existing in (Get-ChildItem -Path $wikiRoot -File -Recurse -Force |
+            Where-Object { $_.FullName -notlike (Join-Path $wikiRoot '.git*') })) {
+        $relative = [System.IO.Path]::GetRelativePath($wikiRoot, $existing.FullName)
+        if (-not $keep.Contains($relative)) {
+            Remove-Item -LiteralPath $existing.FullName -Force
+            $removed.Add($relative)
+        }
+    }
+
+    Copy-Item -Path (Join-Path $stage '*') -Destination $wikiRoot -Recurse -Force
+
+    Write-Host "Wiki tree at '$wikiRoot': $($pages.Count) pages, $($assets.Count) assets, $($removed.Count) removed."
+
+    return @{
+        Pages    = $pages.ToArray()
+        Assets   = $assets.ToArray()
+        Removed  = $removed.ToArray()
+        WikiPath = $wikiRoot
+    }
+} finally {
+    if (-not $TestOnly) { Remove-Item -LiteralPath $stage -Recurse -Force -ErrorAction Ignore }
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ on:
       - 'Test/Integration/**'
       - 'Test/Dev/**'
       - 'Test/Scripts/**'
+      # Wiki publishing only - listed by name so that changes to build.ps1,
+      # build.psake.ps1, release.yml and test.yml still trigger a build.
+      - '.github/workflows/wiki-sync.yml'
+      - '.github/workflows/sync-wiki.ps1'
   pull_request:
     # Work lands as squash-merged PRs into a release line (alpha for the
     # rewrite, beta-2026 for VB.NET hotfixes); master and beta only receive
@@ -32,6 +36,10 @@ on:
       - 'Test/Integration/**'
       - 'Test/Dev/**'
       - 'Test/Scripts/**'
+      # Wiki publishing only - listed by name so that changes to build.ps1,
+      # build.psake.ps1, release.yml and test.yml still trigger a build.
+      - '.github/workflows/wiki-sync.yml'
+      - '.github/workflows/sync-wiki.ps1'
 
 permissions:
   contents: read

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,79 @@
+name: Sync Wiki
+# Publishes docs\ to https://github.com/markdomansky/WebJEA/wiki.
+#
+# docs\ is the source of truth; the wiki is a generated, read-only mirror of
+# the GA branch. sync-wiki.ps1 does the rendering (page names, link rewriting,
+# sidebar, "generated" banners) - see the comments in that script.
+#
+# The wiki intentionally tracks master only. Docs on alpha/beta describe
+# software nobody has yet, so publishing them would mislead users; they reach
+# the wiki when the line promotes to master.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/wiki-sync.yml'
+      - '.github/workflows/sync-wiki.ps1'
+  # Use this after enabling the wiki, changing the renderer, or to repair a
+  # wiki someone edited by hand.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# One push at a time - the wiki is a git repo and two concurrent pushes to it
+# would reject on non-fast-forward.
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Render docs to wiki
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout docs
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # A wiki lives in its own repository, <repo>.wiki.git, which
+      # actions/checkout cannot address - hence the raw clone. It must already
+      # be initialized (create one page in the web UI once); GitHub does not
+      # create the wiki repo on first push.
+      #
+      # WIKI_TOKEN is a PAT with `repo` scope (classic) or Contents: write
+      # (fine-grained). GITHUB_TOKEN can usually push to a wiki, but that is
+      # not contractual, so a PAT is preferred when the secret exists.
+      - name: Clone wiki
+        env:
+          WIKI_TOKEN: ${{ secrets.WIKI_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TOKEN="${WIKI_TOKEN:-$GH_TOKEN}"
+          git clone "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.wiki.git" wiki
+
+      - name: Render docs
+        shell: pwsh
+        run: |
+          ./.github/workflows/sync-wiki.ps1 `
+            -DocsPath ./docs `
+            -WikiPath ./wiki `
+            -Repo '${{ github.repository }}' `
+            -Ref '${{ github.ref_name }}' | Out-Null
+
+      - name: Commit and push
+        working-directory: wiki
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::notice::Wiki already matches docs/ - nothing to push."
+            exit 0
+          fi
+          git diff --cached --name-status
+          git commit -m "docs: sync wiki from docs/ @ ${GITHUB_SHA::7}"
+          git push origin HEAD
+          echo "::notice::Wiki updated from docs/ at ${GITHUB_SHA::7}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,19 @@ workflow creates the tag itself, only after the build succeeds.
   `breaking` away from `major` in `.releaserc.cjs`: the `2100.0.0` line depends
   on that major bump.
 - `.releaserc.cjs` must stay a `.cjs` file; a `.releaserc.yml` would shadow it.
+
+## The wiki is generated from docs\
+
+Never edit the GitHub wiki, and never treat it as a source of content: pushes to
+`master` that touch `docs\` regenerate it wholesale via
+`.github/workflows/wiki-sync.yml` + `sync-wiki.ps1`. All user documentation is
+authored in `docs\`.
+
+- Adding a docs file whose name would make a poor wiki title (lowercase, or an
+  abbreviation) means adding an entry to `$PageNameOverrides` in
+  `.github/workflows/sync-wiki.ps1`.
+- A relative `*.md` link that points at no file in `docs\` **fails the sync
+  workflow** by design. Verify with
+  `.\.github\workflows\sync-wiki.ps1 -WikiPath . -TestOnly`, which renders to a
+  temp folder and writes nothing.
+- See the Documentation section of CONTRIBUTING.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,3 +83,44 @@ Two hand-made tags exist and must never be deleted or recreated:
 
 Never create any other `v*` tag by hand and never edit a version string in the
 source: the workflow stamps the version into the build with `build.ps1 -Version`.
+
+## Documentation
+
+User documentation lives in [`docs/`](docs/README.md) and is edited there, the
+same way as code: topic branch, pull request, squash-merge. Docs-only changes
+cut no release - `release.yml` and `test.yml` both ignore `docs/**` and `**/*.md`.
+
+The [wiki](https://github.com/markdomansky/WebJEA/wiki) is **generated**, not
+authored. On every push to `master` that touches `docs/`,
+`.github/workflows/wiki-sync.yml` runs `.github/workflows/sync-wiki.ps1`, which
+renders `docs/` into the wiki repository and force-replaces its contents. Any
+page edited in the wiki UI is silently overwritten on the next sync, and a page
+the docs no longer produce is deleted. Because the trigger is `master` only, the
+wiki always describes the release users can download - docs written on `alpha`
+appear when that line is promoted.
+
+What the renderer does to each file (details in the script's comment header):
+
+- `docs/README.md` becomes `Home.md`; other file names become wiki page titles,
+  with readable names for the lowercase ones supplied by `$PageNameOverrides` in
+  the script. **Adding a docs file with a lowercase or unclear name means adding
+  an entry there**, otherwise it publishes as e.g. "Powershell7".
+- Links between docs lose their `.md` (`[x](Usage.md)` → `[x](Usage)`), anchors
+  preserved. A `*.md` link that resolves to no docs file **fails the workflow** -
+  that is the guard against typos and stale links.
+- Links reaching outside `docs/` (`../readme.md`, `../CONTRIBUTING.md`) become
+  absolute `github.com` URLs on `master`, since the wiki cannot see the code.
+- Every page gets a "this page is generated" banner, plus a `_Sidebar.md` built
+  from the headings and links in `docs/README.md` and a `_Footer.md`.
+
+Preview the output before pushing - this renders to a temp folder and changes
+nothing:
+
+```powershell
+.\.github\workflows\sync-wiki.ps1 -WikiPath . -TestOnly
+```
+
+Use the workflow's **Run workflow** button to repair the wiki after someone
+edits it by hand, or after changing the renderer. The workflow pushes with
+`secrets.WIKI_TOKEN` when that secret exists (a PAT with `repo`, or
+fine-grained Contents: write) and falls back to `GITHUB_TOKEN`.

--- a/ReleaseFiles/README.md
+++ b/ReleaseFiles/README.md
@@ -1,1 +1,5 @@
+See the installation guide:
+https://github.com/markdomansky/WebJEA/blob/master/docs/Installation.md
+
+The project wiki mirrors that same document:
 https://github.com/markdomansky/WebJEA/wiki/Installation

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,0 +1,154 @@
+# Installation
+
+WebJEA ships with `Deploy.ps1`, which installs and configures a complete
+IIS-hosted deployment: it installs the Windows features and DSC modules it needs,
+creates the IIS site and application pool, copies the site files, lays down a
+starter configuration, and optionally configures HTTPS.
+
+`Deploy.ps1` is driven by a settings file — you do not edit the script itself.
+`settings.template.jsonc` ships alongside it as a starting point.
+
+## Typical/Recommended installation
+
+1. [Download](https://github.com/markdomansky/WebJEA/releases) the release zip and
+   extract it on the server, e.g. to `C:\Source`. `Deploy.ps1`,
+   `settings.template.jsonc` and the `site` folder are in the root of the zip;
+   `Deploy.ps1` deploys the `site` folder sitting next to it, so keep them
+   together.
+2. Create an SSL certificate covering the FQDN users will browse to, import it
+   into the `LocalMachine\My` store **with its private key**, and note the
+   thumbprint (no spaces, no hidden characters). *Optional but strongly
+   recommended — see
+   [System Requirements](System-Requirements.md#certificate-recommended).*
+3. Create a group Managed Service Account (gMSA) for the application pool to run
+   as — see [Creating a gMSA](#creating-a-gmsa) below. A standard AD user account
+   with a password also works.
+4. Copy `settings.template.jsonc` to e.g. `settings.jsonc` and fill it in — every
+   setting is described in the [settings reference](#settings-reference) below.
+5. From an **elevated** PowerShell prompt on the target server, run:
+
+   ```powershell
+   .\Deploy.ps1 -SettingsFile .\settings.jsonc
+   ```
+
+   Add `-TestOnly` to see what would change without changing it, or restrict the
+   run to part of the deployment with `-OnlySections` (see
+   [Deploy.ps1 options](#deployps1-options)).
+
+While not strictly required, a reboot is recommended after deployment, as is
+running Windows Update — several web components are installed during the run.
+
+After the reboot, browse to `https://<your SiteFQDN>/`. By default, machine local
+administrators have access to the default page. It should execute and display a
+form demonstrating all of the major features of WebJEA.
+
+## Settings reference
+
+These are the keys in `settings.template.jsonc`. The file is JSON with comments
+(`jsonc`) — set your editor's language mode to JSONC so the comments render
+correctly.
+
+| Setting | Description |
+| ------- | ----------- |
+| `SiteName` | Name of the IIS site to create. |
+| `SitePath` | Folder to create the IIS site in, e.g. `C:\inetpub\webjea`. The `site` folder from the release is copied here. |
+| `SiteFQDN` | Binding FQDN for the website. Must match the name on your SSL certificate. For HTTP only, `*` is accepted. |
+| `AppPoolName` | Name of the IIS application pool to create. |
+| `AppPoolUserName` | Application pool identity. A gMSA (trailing `$`, empty password) is strongly recommended; see [Creating a gMSA](#creating-a-gmsa). **Scripts execute as this account.** |
+| `AppPoolPassword` | Password for `AppPoolUserName`. Leave empty for a gMSA. Storing a password here is one more reason to prefer a gMSA. |
+| `AppPoolLoadUserProfile` | Must be `true` if your scripts create and import remote PSSessions. `false` is marginally more secure. |
+| `ScriptsPath` | Where WebJEA's scripts and `config.json` are placed, e.g. `c:\webjea`. **If the folder already contains files, this step is skipped** so your customizations are never overwritten. |
+| `LogPath` | Folder for WebJEA's log files. |
+| `LogFile` | Application log file name, e.g. `webjea.log`. |
+| `LogUsageFile` | Simplified usage log, e.g. `webjea-usage.log` — a flat format suited to importing into Excel or another analysis tool. |
+| `CertThumbprint` | Thumbprint of a certificate in the `LocalMachine\My` store covering `SiteFQDN`, imported with its private key. **If empty or invalid, HTTPS is not configured and the site is served over HTTP.** |
+| `RedirectPort80To443` | Redirect HTTP to HTTPS. Only applied when `CertThumbprint` is set and valid. |
+| `EnableBackwardCompatibility` | Adds a URL Rewrite rule issuing a 301 from `/WebJEA/*` to the root path. Needed only when migrating from an older release that was installed as a `/WebJEA` sub-application; leave `false` for a fresh install. |
+| `DisableDefaultWebsite` | Disables the IIS Default Web Site. Recommended — it usually listens on port 80 and will otherwise conflict with the WebJEA site. Set `false` to keep it, and change the port on one of the two. |
+
+## Deploy.ps1 options
+
+| Parameter | Purpose |
+| --------- | ------- |
+| `-SettingsFile <path>` | **Required.** The settings file described above. |
+| `-TestOnly` | Evaluate every step and report what would change, without changing anything. Run this first. |
+| `-OnlySections <names>` | Restrict the run to one or more of `PowerShell`, `Server`, `WebServer`, `WebJEA`, `Finalize` (default `All`). |
+| `-OnlyReturnSteps` | Print the deployment steps without executing them. |
+| `-OnlyReturnSettings` | Print the resolved settings without executing anything — handy for confirming the file parsed as you expect. |
+
+The sections run in order:
+
+| Section | Does |
+| ------- | ---- |
+| `PowerShell` | NuGet package provider, WinRM, and the DSC resource modules the rest of the run depends on. |
+| `Server` | Windows/IIS features, URL Rewrite, **copies the `site` folder to `SitePath`**, and seeds `ScriptsPath` (skipped if that folder already has files). |
+| `WebServer` | The IIS site, application pool and identity, bindings, certificate and HTTP→HTTPS redirect. |
+| `WebJEA` | Sets `basePath` in `config.json` to your `ScriptsPath`. |
+| `Finalize` | Restarts IIS so every change takes effect. |
+
+## Creating a gMSA
+
+If your domain has never used gMSAs, create the KDS root key first (once per
+forest). The `-EffectiveTime` in the past makes the key usable immediately
+instead of after the normal 10-hour replication wait — acceptable in a
+single-DC or lab domain, but in production prefer `Add-KdsRootKey -EffectiveImmediately`
+and wait out the interval:
+
+```powershell
+Add-KdsRootKey -EffectiveTime ((Get-Date).AddHours(-10))
+```
+
+Then create the account and allow the web server to retrieve its password:
+
+```powershell
+New-ADServiceAccount -Name gmsa1 `
+    -DNSHostName gmsa1.domain1.local `
+    -PrincipalsAllowedToRetrieveManagedPassword webserver1$
+
+# Run this on the web server itself:
+Install-ADServiceAccount gmsa1
+```
+
+Grant the gMSA whatever permissions your scripts will need — start with none and
+add as required. In your settings file, use
+`"AppPoolUserName": "domain1\\gmsa1$"` with an empty `AppPoolPassword`.
+
+## Installing to a sub-folder
+
+There is no technical requirement for WebJEA to be installed as its own IIS site.
+`Deploy.ps1` creates one because that is the configuration it can set up
+reliably; if you need WebJEA under an existing site instead, create the virtual
+directory and application yourself and point it at the deployed `site` folder.
+That arrangement is outside what `Deploy.ps1` manages.
+
+If you are moving *from* such a sub-application layout (`/WebJEA`) to a dedicated
+site, set `EnableBackwardCompatibility` to `true` so existing bookmarks and links
+in ticketing systems keep working.
+
+## What's in the release
+
+* The compiled WebJEA site files (`site`)
+* The deployment script (`Deploy.ps1`)
+* The settings template (`settings.template.jsonc`)
+* Starter configuration and demo scripts
+
+## Upgrading
+
+In-place upgrades are straightforward: drop the new `site` files over the
+deployed site folder. Changes take effect immediately; no `iisreset` is required.
+
+**Back up your configuration first.** The site folder holds `web.config` and
+`nlog.config`, which you may well have customized, and a file copy replaces them
+with the release's versions. Your `config.json` is safe as long as it lives in
+`ScriptsPath` outside the site folder, which is where `Deploy.ps1` puts it.
+
+Re-running `Deploy.ps1` is also supported, with the same caveat and one more: the
+site-copy step deliberately has no checksum test, so it **always overwrites** the
+site folder, and it belongs to the `Server` section (not `WebJEA`). To refresh
+only the site files:
+
+```powershell
+.\Deploy.ps1 -SettingsFile .\settings.jsonc -OnlySections Server,Finalize
+```
+
+Re-apply your `web.config` and `nlog.config` changes afterwards.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# WebJEA Documentation
+
+WebJEA dynamically builds web forms for any PowerShell script — parsing the script for
+description, parameters, and validation — and runs it under a controlled service
+identity for users you authorize.
+
+## Getting started
+
+* [System Requirements](System-Requirements.md)
+* [Installation](Installation.md)
+* [Usage](Usage.md)
+* [Tips](Tips.md)
+
+## Contributing
+
+* [Releasing](../CONTRIBUTING.md) — release lines, how PR titles decide versions
+
+## About these documents
+
+This folder is the source of truth for WebJEA's documentation. The
+[project wiki](https://github.com/markdomansky/WebJEA/wiki) is a generated,
+read-only mirror of this folder as it stands on `master`, republished
+automatically by `.github/workflows/wiki-sync.yml` — so it always shows the docs
+for the release you can actually download. **Edit the files here, not the wiki**;
+wiki edits are overwritten by the next sync. See
+[Documentation](../CONTRIBUTING.md#documentation) in CONTRIBUTING.md.

--- a/docs/System-Requirements.md
+++ b/docs/System-Requirements.md
@@ -1,0 +1,53 @@
+# System Requirements
+
+The system requirements are pretty flexible and will depend on usage.
+
+## Operating system
+
+**Windows Server, domain joined, with IIS.** WebJEA runs as an ASP.NET
+(.NET Framework 4.8) application in an IIS application pool.
+
+WebJEA has been tested on Windows Server 2016 and later with PowerShell 5.1. It
+should work on Windows Server 2012 R2 with PowerShell 4.0, but that has not been
+tested and is not actively supported.
+
+## PowerShell
+
+**PowerShell 5.1** (Windows PowerShell), which is in-box on Windows Server 2016
+and later. Scripts you expose through WebJEA run in this engine.
+
+## Service account
+
+The included `Deploy.ps1` assumes a **gMSA** (group Managed Service Account) for
+the IIS application pool identity — see
+[Creating a gMSA](Installation.md#creating-a-gmsa). A standard AD user account
+also works: set `AppPoolUserName` and `AppPoolPassword` in your settings file,
+accepting that the password is then stored in that file.
+
+Scripts execute in the context of this account, so grant it only the permissions
+your scripts actually need. It does **not** need to be a local administrator on
+the web server.
+
+## Certificate (recommended)
+
+`Deploy.ps1` configures HTTPS when you supply `CertThumbprint`, and skips it
+(serving plain HTTP) when you leave that setting empty. A certificate is not
+technically required, but WebJEA form inputs and script output travel over this
+connection — if you pass sensitive data to or from the user, plain HTTP exposes
+it to untrusted networks. Use a certificate in any environment that matters.
+
+The certificate must cover the `SiteFQDN` users will browse to and must be
+imported into the `LocalMachine\My` store with its private key.
+
+## CPU / RAM
+
+There are no firm CPU or RAM requirements beyond Microsoft's recommendations for
+the Windows Server version you are running. Usage drives requirements: WebJEA has
+been demonstrated to work on 1 CPU and 1 GB of RAM and runs reliably on 2 CPU
+with 4 GB of RAM. What your scripts do will dominate.
+
+## Disk
+
+A few MB beyond your base Windows installation. Again, what you do in PowerShell
+will drive the real disk requirements — as will your log retention, since WebJEA
+writes both an application log and a usage log (`LogPath` in your settings file).

--- a/docs/Tips.md
+++ b/docs/Tips.md
@@ -1,0 +1,38 @@
+# Tips
+
+General tips on how to do things that WebJEA doesn't currently support.
+
+## Adding a password field
+
+Sometimes you want a form field to be masked. WebJEA renders parameters as plain
+text inputs, but each input's `id` is the parameter name, so a small addition to
+`resources/startup.js` (in the deployed site folder) can switch chosen fields to
+password inputs.
+
+Replace `Password` with the name of the parameter you want masked. If you use a
+generic name such as `$Password` across your scripts, one entry covers all of
+them; add more names to the array to mask several fields.
+
+```js
+// startup.js — mask the listed parameter names
+$(function () {
+    var maskedFields = ['Password']; // add each parameter name to mask
+
+    maskedFields.forEach(function (name) {
+        // The rendered id is the parameter name. The [id$=] fallback also
+        // matches if a future layout nests the inputs in a naming container.
+        $('#' + name + ', input[id$="_' + name + '"]')
+            .filter('input[type="text"]')
+            .attr('type', 'password');
+    });
+});
+```
+
+The form is rendered server-side, so the controls already exist when the document
+is ready — no need to watch for them.
+
+**This is presentation only.** Masking the input stops someone reading the value
+over the user's shoulder; it does not change how the value is transmitted or
+handled. Set `LogParameters` to `false` on any command taking a secret (see
+[Usage](Usage.md)), or the value is written to the audit log in clear text, and
+make sure the site is served over HTTPS.

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,0 +1,57 @@
+# Usage
+
+## Concepts
+
+* WebJEA is controlled by a JSON configuration file, `config.json`, located in
+  your scripts folder (the `ScriptsPath` you chose during
+  [installation](Installation.md), e.g. `c:\webjea\config.json`).
+* The file has a JSON schema (`schemas/` in this repository). Keep the `$schema`
+  line in your config and editors like VS Code will validate and autocomplete it
+  as you edit.
+* You can also edit the file with the
+  [WebJEAConfig](https://www.powershellgallery.com/packages/WebJEAConfig)
+  PowerShell module ([repo](https://github.com/markdomansky/WebJEAConfig)), which
+  wraps the file in basic Get/Set/New/Remove cmdlets:
+  * Open the file with `Open-WebJEAFile`
+  * Make changes with `Get`/`Set-Config` and `Get`/`Set`/`New`/`Remove-Command`
+  * Save with `Save-WebJEAFile`
+
+## Top-level settings
+
+| Setting | Description |
+| ------- | ----------- |
+| `Title` | The page title displayed in WebJEA. |
+| `BasePath` | Default folder for scripts referenced with a relative path. `Deploy.ps1` sets this to your `ScriptsPath`. |
+| `LogParameters` | Whether form inputs are written to the audit log. Default `true`; can be overridden per command. |
+| `PermittedGroups` | Default access groups, in `domain\group` format. Members have access to **all** commands. |
+| `ShowVerbose` | Show verbose output when a command is run by a member of the global permitted groups. Default `true`. |
+| `DefaultCommandId` | `Id` of the command to display by default. |
+| `HtmlLanguage` | Language for HTML output, used by screen readers and assistive technologies. Default `en-US`. |
+| `SendTelemetry` | Anonymized usage statistics. Set `false` to disable. |
+| `Commands` | The list of commands — see below. |
+
+## Commands
+
+Each entry in `Commands` exposes one script as a web form.
+
+| Setting | Description |
+| ------- | ----------- |
+| `Id` | **Required.** Unique identifier, used in the URL (`?id=<value>`). |
+| `DisplayName` | Friendly name presented to users. |
+| `Synopsis` | Description shown on the dashboard beneath the command title. May contain HTML, which makes it a good way to point users at the right command. If specified, it overrides the synopsis found in the script. |
+| `Script` | The script the form is generated from, and which runs on submit. Parameter sets are **not** supported; most other advanced function features are. |
+| `OnloadScript` | Script executed when the command's page loads. It should take no parameters and return quickly. |
+| `LogParameters` | Override the config-level `LogParameters` for this command. |
+| `PermittedGroups` | Users or groups with access to this command, local or domain, in `domain\user` format. `*` grants access to all users. |
+| `RenderMode` | How the command's output is rendered: `Legacy` or `Markdown`. |
+
+## Access control
+
+A user sees only the commands they have access to. Access comes from the
+top-level `PermittedGroups` (which applies to every command) plus the command's
+own `PermittedGroups`. Group and user names are resolved against Active Directory
+by the application pool identity, so that account must be able to read AD.
+
+Remember that scripts execute as the application pool identity, not as the
+signed-in user — `PermittedGroups` decides who may *invoke* a script, and the
+service account decides what that script *can do*.

--- a/readme.md
+++ b/readme.md
@@ -62,13 +62,13 @@ There are some limitations with WebJEA.  All of these are considered areas for f
 
 ## Installation
 
-A DSC push configuration template is provided to get you going quickly.  Check the [Documentation](https://github.com/markdomansky/WebJEA/wiki) for more information.
+`Deploy.ps1` is provided to get you going quickly.  Check the [Documentation](docs/README.md) for more information, in particular the [Installation guide](docs/Installation.md) and [System Requirements](docs/System-Requirements.md).
 
 Installation Steps:
 1. Build a server, get a certificate, create a managed service account.
 2. Go to [Releases](https://github.com/markdomansky/WebJEA/releases), download and extract the latest release.
-3. Modify the DSCDeploy.ps1 with the machine name, certificate thumbprint, MSA username, and customize deployment folder, etc.
-4. execute DSCDeploy.ps1 configuration.  This will download and install the necessary DSC modules, the latest package, then start installation.
+3. Copy `settings.template.jsonc` and fill in the machine name, certificate thumbprint, MSA username, deployment folders, etc.  Every setting is described in the [settings reference](docs/Installation.md#settings-reference).
+4. From an elevated prompt, run `.\Deploy.ps1 -SettingsFile .\settings.jsonc`.  This installs the necessary DSC modules and Windows features, then deploys the site.  Add `-TestOnly` first to see what would change.
 5. Reboot should not be needed, but is recommended following first deployment.
 
 A demo script is included to confirm operation. Use the WebJEAConfig module to add additional scripts below.


### PR DESCRIPTION
Moves WebJEA's user documentation out of the wiki and into `docs/`, and turns the wiki into a generated, read-only mirror. After this, nobody works in `markdomansky/WebJEA.wiki`.

## The five wiki pages, ported and corrected

`docs/README.md` (→ wiki `Home`), `Installation.md`, `System-Requirements.md`, `Usage.md`, `Tips.md`.

They are corrected against what this line actually ships, because the wiki had drifted:

- **Installation** — the wiki described `DSCDeploy.ps1` with inline variables. The release carries `Deploy.ps1 -SettingsFile` driven by `settings.template.jsonc`, so this documents that interface, every settings key, the `PowerShell`/`Server`/`WebServer`/`WebJEA`/`Finalize` sections, `-TestOnly`, and the gMSA creation steps. Notes that the site-copy step always overwrites and lives in `Server`, not `WebJEA`.
- **Usage** — gains the full top-level and per-command settings from `schemas/webjea-config-2026-04.schema.json`; keeps the `WebJEAConfig` module links.
- **Tips** — drops the `psparam_` id prefix, which no longer exists in the app; control ids are the bare parameter name. Adds the caveat that masking is presentation only, so `LogParameters` still needs turning off for secrets.
- **System Requirements** — CPU/RAM and disk guidance kept verbatim; OS/PowerShell/service-account/certificate sections corrected.

## Publishing

`.github/workflows/wiki-sync.yml` runs on pushes to `master` touching `docs/`, plus `workflow_dispatch`. It renders via `.github/workflows/sync-wiki.ps1`:

- `README.md` → `Home.md`; other file names become page titles, with `$PageNameOverrides` for names the file name cannot express
- intra-docs links lose their `.md`, anchors preserved
- links out of `docs/` become absolute `github.com` URLs
- a "generated — edit `docs/` instead" banner on every page, plus `_Sidebar.md` built from `README.md` and a `_Footer.md`
- **a `*.md` link resolving to no docs file fails the workflow** — the guard against stale links
- stale pages are deleted, so the wiki mirrors rather than accumulates

Preview locally with `.\.github\workflows\sync-wiki.ps1 -WikiPath . -TestOnly` (renders to a temp folder, writes nothing).

## Release safety

The two wiki-sync files are added to the `release.yml`/`test.yml` `paths-ignore` lists **by name**, not via a `.github/workflows/**` glob — so changes to `build.ps1`, `build.psake.ps1`, `release.yml` and `test.yml` still trigger a build. This change is docs + ignored paths only, so it cuts no release.

## Follow-ups for the repo owner

- **No `WIKI_TOKEN` secret exists**, so the workflow falls back to `GITHUB_TOKEN`. That usually pushes to a wiki but is not contractual; add a PAT as `WIKI_TOKEN` if the first run fails on push.
- Consider ticking **Settings → Wikis → Restrict editing to collaborators only**, since wiki edits are now discarded on the next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)