### PR TITLE
docs: carry the wiki sync tooling onto the rewrite line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,10 @@ on:
       - 'Test/Integration/**'
       - 'Test/Dev/**'
       - 'Test/Scripts/**'
+      # Wiki publishing only - listed by name so that changes to build.ps1,
+      # build.psake.ps1, release.yml and test.yml still trigger a build.
+      - '.github/workflows/wiki-sync.yml'
+      - '.github/workflows/sync-wiki.ps1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-wiki.ps1
+++ b/.github/workflows/sync-wiki.ps1
@@ -1,0 +1,299 @@
+<#
+.SYNOPSIS
+    Renders docs\ into a GitHub wiki working tree.
+
+.DESCRIPTION
+    docs\ in this repo is the single source of truth for user documentation.
+    The wiki at https://github.com/markdomansky/WebJEA/wiki is a generated
+    mirror - nobody edits it directly. This script converts docs\ into the
+    layout a wiki clone expects and is invoked by wiki-sync.yml on every push
+    to master that touches docs\.
+
+    Conversions applied:
+
+    1. File name -> wiki page name. Wiki page titles come from the file name
+       with hyphens shown as spaces, so docs\README.md becomes Home.md and the
+       lowercase file names get readable titles via $PageNameOverrides.
+    2. Intra-docs links. [x](Usage.md) and [x](docker.md#configuration) become
+       [x](Usage) and [x](Docker#configuration) - wiki links carry no .md.
+       An unresolvable *.md link is a hard error, which is how a typo or a
+       deleted page gets caught before it reaches the wiki.
+    3. Links out of docs\ (../readme.md, ../docker/examples/...) become
+       absolute github.com/<repo>/blob|tree/<ref>/... URLs, since the wiki is
+       a separate repository with no view of the code.
+    4. A "generated - edit docs\ instead" banner is injected into every page,
+       plus a _Sidebar.md built from docs\README.md and a _Footer.md.
+    5. Non-markdown files under docs\ (images and the like) are copied through
+       with their relative paths intact.
+
+    Anything left in the wiki tree that this run did not produce is deleted, so
+    the wiki is a true mirror rather than an accumulation.
+
+.PARAMETER DocsPath
+    Path to the docs folder to render. Default: docs\ beside this repo root.
+
+.PARAMETER WikiPath
+    Path to a checkout of the <repo>.wiki repository. Its tracked content is
+    replaced by the rendered output.
+
+.PARAMETER Repo
+    owner/name used to build absolute links back into the code repository.
+    Default: markdomansky/WebJEA.
+
+.PARAMETER Ref
+    Branch or tag the absolute links point at. Default: master.
+
+.PARAMETER TestOnly
+    Render into a temporary folder and report what would change, without
+    touching WikiPath.
+
+.EXAMPLE
+    .\sync-wiki.ps1 -WikiPath ..\WebJEA.wiki -TestOnly
+
+.EXAMPLE
+    .\sync-wiki.ps1 -WikiPath $env:RUNNER_TEMP\wiki
+
+.OUTPUTS
+    Hashtable:
+    - Pages:   rendered page file names
+    - Assets:  copied non-markdown files
+    - Removed: files deleted from the wiki tree
+    - WikiPath: where the output was written
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$DocsPath = (Join-Path $PSScriptRoot '..\..\docs'),
+
+    [Parameter(Mandatory)]
+    [string]$WikiPath,
+
+    [Parameter()]
+    [string]$Repo = 'markdomansky/WebJEA',
+
+    [Parameter()]
+    [string]$Ref = 'master',
+
+    [Parameter()]
+    [switch]$TestOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Wiki page name for a docs file base name. Anything not listed is title-cased
+# per hyphen-separated word, which already reads correctly for the Title-Case
+# file names (System-Requirements -> "System Requirements"). Add an entry here
+# when a new docs file needs a title the file name cannot express.
+$PageNameOverrides = @{
+    'README'               = 'Home'
+    'deployment-migration' = 'Deployment-and-Migration'
+    'dev'                  = 'Development-Auto-Login'
+    'entra'                = 'Entra-ID'
+    'powershell7'          = 'PowerShell-7'
+    'windows'              = 'Windows-Authentication'
+}
+
+function Get-PageName {
+    param([Parameter(Mandatory)][string]$BaseName)
+
+    if ($PageNameOverrides.ContainsKey($BaseName)) {
+        return $PageNameOverrides[$BaseName]
+    }
+    # Title-case each word; leave the hyphens, GitHub renders them as spaces.
+    return (($BaseName -split '-' | ForEach-Object {
+        if ($_.Length -gt 0) { $_.Substring(0, 1).ToUpperInvariant() + $_.Substring(1) } else { $_ }
+    }) -join '-')
+}
+
+$docsRoot = (Resolve-Path $DocsPath).Path
+$repoUrl = "https://github.com/$Repo"
+
+$markdown = Get-ChildItem -Path $docsRoot -Filter '*.md' -File | Sort-Object Name
+if (-not $markdown) { throw "No markdown files found under '$docsRoot'." }
+
+# Source file name (lowercased) -> wiki page name, for link rewriting.
+$pageMap = @{}
+foreach ($file in $markdown) {
+    $pageMap[$file.Name.ToLowerInvariant()] = Get-PageName -BaseName $file.BaseName
+}
+
+function Convert-Links {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Text,
+        [Parameter(Mandatory)][string]$SourceName
+    )
+
+    $broken = [System.Collections.Generic.List[string]]::new()
+
+    $result = [regex]::Replace($Text, '(?<=\]\()([^)\s]+)(?=\))', {
+        param($m)
+        $target = $m.Groups[1].Value
+
+        # Absolute URLs, mailto: and same-page anchors need no change - wiki
+        # anchors are generated from headings exactly as they are on github.com.
+        if ($target -match '^([a-z][a-z0-9+.-]*:|#|//)') { return $target }
+
+        # Anything reaching outside docs\ lives in the code repo, not the wiki.
+        if ($target.StartsWith('../')) {
+            $path = $target.Substring(3)
+            $kind = if ($path.EndsWith('/')) { 'tree' } else { 'blob' }
+            return "$repoUrl/$kind/$Ref/$($path.TrimEnd('/'))"
+        }
+
+        $file, $anchor = $target -split '#', 2
+        if ($file -notmatch '\.md$') { return $target }
+
+        $page = $pageMap[$file.ToLowerInvariant()]
+        if (-not $page) {
+            $broken.Add("$SourceName -> $target")
+            return $target
+        }
+        if ($anchor) { return "$page#$anchor" }
+        return $page
+    })
+
+    return [pscustomobject]@{ Text = $result; Broken = $broken }
+}
+
+function Add-Banner {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [Parameter(Mandatory)][string]$SourceName
+    )
+
+    $banner = "> **This page is generated.** It mirrors " +
+        "[``docs/$SourceName``]($repoUrl/blob/$Ref/docs/$SourceName) in the " +
+        "[WebJEA repository]($repoUrl). Edits made here are overwritten by the " +
+        "next sync - please open a pull request against ``docs/`` instead."
+
+    $lines = $Text -split "`r?`n"
+    # Keep the H1 first so the page still reads correctly, banner right below it.
+    if ($lines.Count -gt 0 -and $lines[0] -match '^#\s') {
+        return (@($lines[0], '', $banner) + $lines[1..($lines.Count - 1)]) -join "`n"
+    }
+    return (@($banner, '') + $lines) -join "`n"
+}
+
+function New-Sidebar {
+    param([Parameter(Mandatory)][string]$ReadmeText)
+
+    # docs\README.md is already a complete, grouped index of every page, so the
+    # sidebar is that index with the prose descriptions trimmed off.
+    $out = [System.Collections.Generic.List[string]]::new()
+    $out.Add("### [WebJEA]($($pageMap['readme.md']))")
+    $out.Add('')
+
+    # A heading is only emitted once a bullet turns up under it, so prose-only
+    # sections of README (such as "About these documents") leave no empty group.
+    $pending = $null
+    foreach ($line in ($ReadmeText -split "`r?`n")) {
+        if ($line -match '^##\s+(.+?)\s*$') {
+            $pending = $Matches[1]
+            continue
+        }
+        # Only the bullet's own line carries the link; wrapped description lines
+        # are indented and get skipped, which is what we want in a sidebar.
+        if ($line -match '^\*\s+(\[[^]]+\]\([^)]+\))') {
+            if ($pending) {
+                if ($out[$out.Count - 1] -ne '') { $out.Add('') }
+                $out.Add("**$pending**")
+                $pending = $null
+            }
+            $out.Add("* $($Matches[1])")
+        }
+    }
+
+    return ($out -join "`n").Trim() + "`n"
+}
+
+$stage = Join-Path ([System.IO.Path]::GetTempPath()) ("webjea-wiki-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $stage -Force | Out-Null
+
+try {
+    $broken = [System.Collections.Generic.List[string]]::new()
+    $pages = [System.Collections.Generic.List[string]]::new()
+    $readmeRendered = $null
+
+    foreach ($file in $markdown) {
+        $page = $pageMap[$file.Name.ToLowerInvariant()]
+        $raw = Get-Content -LiteralPath $file.FullName -Raw
+
+        $converted = Convert-Links -Text $raw -SourceName $file.Name
+        $broken.AddRange($converted.Broken)
+
+        if ($file.Name -ieq 'README.md') { $readmeRendered = $converted.Text }
+
+        $body = (Add-Banner -Text $converted.Text -SourceName $file.Name).TrimEnd() + "`n"
+        Set-Content -LiteralPath (Join-Path $stage "$page.md") -Value $body -NoNewline -Encoding utf8
+        $pages.Add("$page.md")
+    }
+
+    if ($broken.Count -gt 0) {
+        throw "Unresolved documentation links (fix the link or add the page to docs\):`n  " +
+            ($broken -join "`n  ")
+    }
+
+    if ($readmeRendered) {
+        Set-Content -LiteralPath (Join-Path $stage '_Sidebar.md') `
+            -Value (New-Sidebar -ReadmeText $readmeRendered) -NoNewline -Encoding utf8
+        $pages.Add('_Sidebar.md')
+    }
+
+    $footer = "_Generated from [``docs/``]($repoUrl/tree/$Ref/docs) on the " +
+        "``$Ref`` branch of the [WebJEA repository]($repoUrl). " +
+        "Do not edit the wiki directly - changes here are overwritten._`n"
+    Set-Content -LiteralPath (Join-Path $stage '_Footer.md') -Value $footer -NoNewline -Encoding utf8
+    $pages.Add('_Footer.md')
+
+    # Images and other attachments referenced by the docs, path preserved.
+    $assets = [System.Collections.Generic.List[string]]::new()
+    foreach ($asset in (Get-ChildItem -Path $docsRoot -File -Recurse | Where-Object { $_.Extension -ne '.md' })) {
+        $relative = [System.IO.Path]::GetRelativePath($docsRoot, $asset.FullName)
+        $destination = Join-Path $stage $relative
+        New-Item -ItemType Directory -Path (Split-Path -Parent $destination) -Force | Out-Null
+        Copy-Item -LiteralPath $asset.FullName -Destination $destination -Force
+        $assets.Add($relative)
+    }
+
+    if ($TestOnly) {
+        Write-Host "Rendered $($pages.Count) pages and $($assets.Count) assets to '$stage' (test only)."
+        return @{
+            Pages    = $pages.ToArray()
+            Assets   = $assets.ToArray()
+            Removed  = @()
+            WikiPath = $stage
+        }
+    }
+
+    $wikiRoot = (Resolve-Path $WikiPath).Path
+
+    # Replace the wiki's content wholesale: anything the docs no longer produce
+    # is a stale page and must go. .git is the wiki clone's own metadata.
+    $removed = [System.Collections.Generic.List[string]]::new()
+    $keep = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in $pages) { $keep.Add($name) | Out-Null }
+    foreach ($name in $assets) { $keep.Add($name) | Out-Null }
+
+    foreach ($existing in (Get-ChildItem -Path $wikiRoot -File -Recurse -Force |
+            Where-Object { $_.FullName -notlike (Join-Path $wikiRoot '.git*') })) {
+        $relative = [System.IO.Path]::GetRelativePath($wikiRoot, $existing.FullName)
+        if (-not $keep.Contains($relative)) {
+            Remove-Item -LiteralPath $existing.FullName -Force
+            $removed.Add($relative)
+        }
+    }
+
+    Copy-Item -Path (Join-Path $stage '*') -Destination $wikiRoot -Recurse -Force
+
+    Write-Host "Wiki tree at '$wikiRoot': $($pages.Count) pages, $($assets.Count) assets, $($removed.Count) removed."
+
+    return @{
+        Pages    = $pages.ToArray()
+        Assets   = $assets.ToArray()
+        Removed  = $removed.ToArray()
+        WikiPath = $wikiRoot
+    }
+} finally {
+    if (-not $TestOnly) { Remove-Item -LiteralPath $stage -Recurse -Force -ErrorAction Ignore }
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ on:
       - 'Test/Integration/**'
       - 'Test/Dev/**'
       - 'Test/Scripts/**'
+      # Wiki publishing only - listed by name so that changes to build.ps1,
+      # build.psake.ps1, release.yml and test.yml still trigger a build.
+      - '.github/workflows/wiki-sync.yml'
+      - '.github/workflows/sync-wiki.ps1'
   pull_request:
     # Work lands as squash-merged PRs into a release line (alpha for the
     # rewrite, beta-2026 for VB.NET hotfixes); master and beta only receive
@@ -32,6 +36,10 @@ on:
       - 'Test/Integration/**'
       - 'Test/Dev/**'
       - 'Test/Scripts/**'
+      # Wiki publishing only - listed by name so that changes to build.ps1,
+      # build.psake.ps1, release.yml and test.yml still trigger a build.
+      - '.github/workflows/wiki-sync.yml'
+      - '.github/workflows/sync-wiki.ps1'
 
 permissions:
   contents: read

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,79 @@
+name: Sync Wiki
+# Publishes docs\ to https://github.com/markdomansky/WebJEA/wiki.
+#
+# docs\ is the source of truth; the wiki is a generated, read-only mirror of
+# the GA branch. sync-wiki.ps1 does the rendering (page names, link rewriting,
+# sidebar, "generated" banners) - see the comments in that script.
+#
+# The wiki intentionally tracks master only. Docs on alpha/beta describe
+# software nobody has yet, so publishing them would mislead users; they reach
+# the wiki when the line promotes to master.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/wiki-sync.yml'
+      - '.github/workflows/sync-wiki.ps1'
+  # Use this after enabling the wiki, changing the renderer, or to repair a
+  # wiki someone edited by hand.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# One push at a time - the wiki is a git repo and two concurrent pushes to it
+# would reject on non-fast-forward.
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Render docs to wiki
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout docs
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # A wiki lives in its own repository, <repo>.wiki.git, which
+      # actions/checkout cannot address - hence the raw clone. It must already
+      # be initialized (create one page in the web UI once); GitHub does not
+      # create the wiki repo on first push.
+      #
+      # WIKI_TOKEN is a PAT with `repo` scope (classic) or Contents: write
+      # (fine-grained). GITHUB_TOKEN can usually push to a wiki, but that is
+      # not contractual, so a PAT is preferred when the secret exists.
+      - name: Clone wiki
+        env:
+          WIKI_TOKEN: ${{ secrets.WIKI_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TOKEN="${WIKI_TOKEN:-$GH_TOKEN}"
+          git clone "https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.wiki.git" wiki
+
+      - name: Render docs
+        shell: pwsh
+        run: |
+          ./.github/workflows/sync-wiki.ps1 `
+            -DocsPath ./docs `
+            -WikiPath ./wiki `
+            -Repo '${{ github.repository }}' `
+            -Ref '${{ github.ref_name }}' | Out-Null
+
+      - name: Commit and push
+        working-directory: wiki
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::notice::Wiki already matches docs/ - nothing to push."
+            exit 0
+          fi
+          git diff --cached --name-status
+          git commit -m "docs: sync wiki from docs/ @ ${GITHUB_SHA::7}"
+          git push origin HEAD
+          echo "::notice::Wiki updated from docs/ at ${GITHUB_SHA::7}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,19 @@ workflow creates the tag itself, only after the build succeeds.
   `breaking` away from `major` in `.releaserc.cjs`: the `2100.0.0` line depends
   on that major bump.
 - `.releaserc.cjs` must stay a `.cjs` file; a `.releaserc.yml` would shadow it.
+
+## The wiki is generated from docs\
+
+Never edit the GitHub wiki, and never treat it as a source of content: pushes to
+`master` that touch `docs\` regenerate it wholesale via
+`.github/workflows/wiki-sync.yml` + `sync-wiki.ps1`. All user documentation is
+authored in `docs\`.
+
+- Adding a docs file whose name would make a poor wiki title (lowercase, or an
+  abbreviation) means adding an entry to `$PageNameOverrides` in
+  `.github/workflows/sync-wiki.ps1`.
+- A relative `*.md` link that points at no file in `docs\` **fails the sync
+  workflow** by design. Verify with
+  `.\.github\workflows\sync-wiki.ps1 -WikiPath . -TestOnly`, which renders to a
+  temp folder and writes nothing.
+- See the Documentation section of CONTRIBUTING.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,3 +83,44 @@ Two hand-made tags exist and must never be deleted or recreated:
 
 Never create any other `v*` tag by hand and never edit a version string in the
 source: the workflow stamps the version into the build with `build.ps1 -Version`.
+
+## Documentation
+
+User documentation lives in [`docs/`](docs/README.md) and is edited there, the
+same way as code: topic branch, pull request, squash-merge. Docs-only changes
+cut no release - `release.yml` and `test.yml` both ignore `docs/**` and `**/*.md`.
+
+The [wiki](https://github.com/markdomansky/WebJEA/wiki) is **generated**, not
+authored. On every push to `master` that touches `docs/`,
+`.github/workflows/wiki-sync.yml` runs `.github/workflows/sync-wiki.ps1`, which
+renders `docs/` into the wiki repository and force-replaces its contents. Any
+page edited in the wiki UI is silently overwritten on the next sync, and a page
+the docs no longer produce is deleted. Because the trigger is `master` only, the
+wiki always describes the release users can download - docs written on `alpha`
+appear when that line is promoted.
+
+What the renderer does to each file (details in the script's comment header):
+
+- `docs/README.md` becomes `Home.md`; other file names become wiki page titles,
+  with readable names for the lowercase ones supplied by `$PageNameOverrides` in
+  the script. **Adding a docs file with a lowercase or unclear name means adding
+  an entry there**, otherwise it publishes as e.g. "Powershell7".
+- Links between docs lose their `.md` (`[x](Usage.md)` → `[x](Usage)`), anchors
+  preserved. A `*.md` link that resolves to no docs file **fails the workflow** -
+  that is the guard against typos and stale links.
+- Links reaching outside `docs/` (`../readme.md`, `../docker/examples/…`) become
+  absolute `github.com` URLs on `master`, since the wiki cannot see the code.
+- Every page gets a "this page is generated" banner, plus a `_Sidebar.md` built
+  from the headings and links in `docs/README.md` and a `_Footer.md`.
+
+Preview the output before pushing - this renders to a temp folder and changes
+nothing:
+
+```powershell
+.\.github\workflows\sync-wiki.ps1 -WikiPath . -TestOnly
+```
+
+Use the workflow's **Run workflow** button to repair the wiki after someone
+edits it by hand, or after changing the renderer. The workflow pushes with
+`secrets.WIKI_TOKEN` when that secret exists (a PAT with `repo`, or
+fine-grained Contents: write) and falls back to `GITHUB_TOKEN`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,3 +33,13 @@ identity for users you authorize.
 
 * [Releasing](Releasing.md) — release lines (`alpha`, `beta`, `master`,
   `beta-2026`), how PR titles decide versions, promotions and back-merges
+
+## About these documents
+
+This folder is the source of truth for WebJEA's documentation. The
+[project wiki](https://github.com/markdomansky/WebJEA/wiki) is a generated,
+read-only mirror of this folder as it stands on `master`, republished
+automatically by `.github/workflows/wiki-sync.yml` — so it shows the docs for
+the release you can actually download. **Edit the files here, not the wiki**;
+wiki edits are overwritten by the next sync. See
+[Documentation](../CONTRIBUTING.md#documentation) in CONTRIBUTING.md.


### PR DESCRIPTION
Companion to #118. That PR moves the wiki into `docs/` on the VB.NET line and adds the generator; this adds the same tooling to the rewrite line.

## Why it is needed here too

- Promoting `alpha` → `beta` → `master` must not drop `wiki-sync.yml` / `sync-wiki.ps1`.
- `alpha`'s `docs/` gets checked by the same link validation (`*.md` links that resolve to nothing fail the workflow).
- `$PageNameOverrides` in the renderer covers this line's lowercase file names — `authentication`, `deployment-migration`, `dev`, `docker`, `entra`, `powershell7`, `windows` — which master does not have. Verified: all 15 pages render with every link resolving.

## What is not here

`alpha`'s `docs/` already holds the rewritten documentation, so no content is ported. Only the tooling, the CONTRIBUTING/CLAUDE.md notes, and a "the wiki is generated" pointer in `docs/README.md`.

Note the workflow triggers on `master` only, so nothing publishes from this line until it is promoted — which is deliberate: `alpha` docs describe software nobody can download yet.

## Release safety

The two wiki-sync files are added to the `release.yml`/`test.yml` `paths-ignore` lists **by name**, not via a `.github/workflows/**` glob, so changes to `build.ps1`, `build.psake.ps1`, `release.yml` and `test.yml` still trigger a build. Docs + ignored paths only, so this cuts no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)